### PR TITLE
Added message formatting

### DIFF
--- a/bot/services/forwarder.py
+++ b/bot/services/forwarder.py
@@ -1,12 +1,14 @@
 import json
 import discord
 
+from services.message_formatter import format_message
+
 def load_forwards():
     try:
         with open("bot/data/forwards.json", "r") as f:
             forwards = json.load(f)
-    except (FileNotFoundError, json.JSONDecodeError) as e:
-        print(f"Error - Resetting forwards")
+    except (FileNotFoundError, json.JSONDecodeError):
+        print(f"Issue with Forwards storage - Resetting forwards")
         forwards = {}
         save_forwards(forwards)
     return forwards
@@ -16,16 +18,22 @@ def save_forwards(forwards):
         json.dump(forwards, f, indent=4)
 
 def add_dm_forward(forward_from: str, dm_id: str):
+    # Load forwards
     forwards = load_forwards()
+    # Typecast to avoid python key matching issues
     forward_from = str(forward_from)
+
+    # If a config exists, import it
     if forward_from in set(forwards.keys()):
         config = forwards[forward_from]
+    # If not, create a blank one
     else:
         config = {
             "forwardToIDs": [],
             "forwardToChannels": None
         }
 
+    # Add dm to forward to to config
     if dm_id not in config["forwardToIDs"]:
         config["forwardToIDs"].append(dm_id)
 
@@ -34,13 +42,14 @@ def add_dm_forward(forward_from: str, dm_id: str):
     return config
 
 async def send_forward(bot, message, config):
+    ''' Initiate forwarding - Currently only forwards to dms'''
     ids_to_dm = config["forwardToIDs"]
     for user_id in ids_to_dm:
         try:
+            # TODO: This shouldnt all be in the try catch
             user = await bot.fetch_user(user_id)
             dm_channel = await user.create_dm()
-            # For now, return message will just be message content to confirm bots functionallity
-            return_message = message.content
+            return_message = format_message(message)
             await dm_channel.send(return_message)
         except discord.errors.NotFound:
             await message.channel.send(f'Could not forward a DM for {message.author.name} because the user to DM was not found')

--- a/bot/services/message_formatter.py
+++ b/bot/services/message_formatter.py
@@ -1,0 +1,50 @@
+def format_message(message):
+    # Base URL format to create a link to the message
+    base_url = f"https://discord.com/channels/{message.guild.id}/{message.channel.id}/{message.id}"
+    
+    # Header with author and link to the message
+    formatted_message = (
+        f"**Message from {message.author.name}#{message.author.discriminator}**\n"
+        f"[Jump to message]({base_url})\n\n"
+    )
+
+    # Adding the original message content
+    if message.content:
+        formatted_message += f"**Content:**\n{message.content}\n\n"
+
+    # Adding any embeds
+    if message.embeds:
+        formatted_message += "**Embeds:**\n"
+        for embed in message.embeds:
+            formatted_message += embed_to_str(embed) + "\n"
+
+    # Adding any attachments
+    if message.attachments:
+        formatted_message += "**Attachments:**\n"
+        for attachment in message.attachments:
+            formatted_message += f"[{attachment.filename}]({attachment.url})\n"
+
+    return formatted_message
+
+def embed_to_str(embed):
+    """Helper function to convert an embed object to a string."""
+    embed_str = ""
+    if embed.title:
+        embed_str += f"**Title:** {embed.title}\n"
+    if embed.description:
+        embed_str += f"**Description:** {embed.description}\n"
+    for field in embed.fields:
+        embed_str += f"**{field.name}:** {field.value}\n"
+    if embed.footer and embed.footer.text:
+        embed_str += f"**Footer:** {embed.footer.text}\n"
+    if embed.image:
+        embed_str += f"**Image:** [Link]({embed.image.url})\n"
+    if embed.thumbnail:
+        embed_str += f"**Thumbnail:** [Link]({embed.thumbnail.url})\n"
+    if embed.url:
+        embed_str += f"**URL:** {embed.url}\n"
+    if embed.author:
+        embed_str += f"**Author:** {embed.author.name}\n"
+    return embed_str
+
+


### PR DESCRIPTION
- Added a message formatter that can now format messages and all the content involved in them
Example output with an attachment
![image](https://github.com/llarse/Discord-bot-ping-forward/assets/114639743/f5d281b8-eb97-4868-84f7-9205684db4cd)

- Added better commenting 
- Added some TODO's - specifically reformatting the try catch to only have one operation in send_forward